### PR TITLE
models用のstrict-dependenciesルールを追加する

### DIFF
--- a/frontend.js
+++ b/frontend.js
@@ -216,7 +216,6 @@ module.exports = {
             'src/components/page',
             'src/globalStates',
             'src/mocks',
-            'src/models',
             'src/repositories',
             'src/services',
             'src/usecases',

--- a/frontend.js
+++ b/frontend.js
@@ -210,6 +210,20 @@ module.exports = {
           allowSameModule: true,
         },
         {
+          module: 'src/models',
+          allowReferenceFrom: [
+            'src/components',
+            'src/globalStates',
+            'src/mocks',
+            'src/models',
+            'src/repositories',
+            'src/services',
+            'src/usecases',
+            'src/utils/hooks',
+          ],
+          allowSameModule: true,
+        },
+        {
           module: 'src/repositories/*',
           allowReferenceFrom: [
             'src/usecases/*/usecase.ts',

--- a/frontend.js
+++ b/frontend.js
@@ -219,7 +219,6 @@ module.exports = {
             'src/repositories',
             'src/services',
             'src/usecases',
-            'src/utils/hooks',
           ],
           allowSameModule: true,
         },

--- a/frontend.js
+++ b/frontend.js
@@ -212,7 +212,8 @@ module.exports = {
         {
           module: 'src/models',
           allowReferenceFrom: [
-            'src/components',
+            'src/components/model',
+            'src/components/page',
             'src/globalStates',
             'src/mocks',
             'src/models',


### PR DESCRIPTION
[「frontendのmodelsにlibsが依存したくない」というコメント](https://github.com/knowledge-work/knowledgework/pull/21743/commits/35e46a16d2a6fef6d809552f895aac59d5666a54#r1241471308)をいただいたので、eslint の strict-dependencies にルールを追加しました。

現状で import があるディレクトリのみを allowReferenceFrom に含めています。

※1. 試しに作ってみた、という程度のPRですので、このレポジトリのメンテナンスルールと違う、などありましたらrejectで問題ありません。

※2. 現状でも libs から models 配下のインポートが若干あるので、取り込む場合は frontend のソースコードも修正がなりそうです。

``` libs配下をmodelsにgrepした結果
./libs/validationSchema.ts:import { splitEmails } from '@/models/user'
./libs/urlBuilder.ts:import type { AppointmentListQuery } from '@/models/appointment'
./libs/urlBuilder.ts:import type { ExternalShareListQuery } from '@/models/externalShare'
./libs/urlBuilder.ts:import type { Group } from '@/models/group'
./libs/urlBuilder.ts:import type { LearningCheckerAsReport } from '@/models/learningChecker'
./libs/urlBuilder.ts:import type { LearningCourse } from '@/models/learningCourse'
./libs/urlBuilder.ts:import type { LearningCourseSection } from '@/models/learningCourseSection'
./libs/urlBuilder.ts:import type { User } from '@/models/user'
./libs/logReporter/logReporter.ts:import type { Tenant } from '@/models/tenant'
./libs/logReporter/logReporter.ts:import type { User } from '@/models/user'```