### PR TITLE
v6からrecommendedで出なくなったアラートを追加

### DIFF
--- a/base.js
+++ b/base.js
@@ -67,6 +67,9 @@ module.exports = {
     ], // https://github.com/facebook/create-react-app/issues/8107
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-useless-constructor': ['error'],
+    // @typescript-eslint v6でrecommendedからアラートが出なくなったルールを有効化
+    '@typescript-eslint/no-non-null-assertion': 'error',
+    '@typescript-eslint/no-explicit-any': 'error',
 
     /**
      * eslint-comments


### PR DESCRIPTION
[`@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint) のv6 [`recommended`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/eslint-recommended.ts)から
- [`no-non-null-assertion`](https://typescript-eslint.io/rules/no-non-null-assertion/)
- [`no-explicit-any`](https://typescript-eslint.io/rules/no-explicit-any/)
がstrictに移行して、アラートが出なくなったので該当ルールを有効化しました

[V6のconfigのルール表](https://github.com/typescript-eslint/typescript-eslint/discussions/6014)
