### PR TITLE
'plugin:@typescript-eslint/stylistic'の追加

### DIFF
--- a/base.js
+++ b/base.js
@@ -7,6 +7,7 @@ module.exports = {
     'airbnb-base',
     'airbnb-typescript/base',
     'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/stylistic',
     'plugin:eslint-comments/recommended',
     // NOTE(hori-ryota): prettierは全設定の最後に記述する必要があるため、ここでは設定せずextendsする側でそれぞれ設定する
   ],


### PR DESCRIPTION
## 概要
一部スタイル関連のルールが[`@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint) のv5からv6の`recommended`で抜けたため、`@typescript-eslint/stylistic`をbaseのextendsに追加しました


追加されるルールは以下のdiscussionのstyleという行をご確認ください！
[V6のconfigのルール表](https://github.com/typescript-eslint/typescript-eslint/discussions/6014)
