### PR TITLE
chore(ci): fix release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,7 @@ jobs:
           git config user.name '[bot] github action (${{ github.workflow }})'
           git config user.email 'engineer-team@knowledgework.com'
           pnpm version --${{ github.event_name == 'schedule' && 'patch' || github.event.inputs.versionClass }}
+          pnpm release
           echo "new_version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "check": "pnpm check:prettier",
     "check:prettier": "prettier --check .",
     "format": "prettier --write .",
-    "preversion": "echo \"Run check for version $npm_package_version\" && pnpm check",
-    "postversion": "git push --tags && git push origin main && pnpm publish ."
+    "release": "pnpm release:check && pnpm release:publish",
+    "release:check": "echo \"Run check for version $npm_package_version\" && pnpm check",
+    "release:publish": "git push --tags && git push origin main && pnpm publish ."
   },
   "dependencies": {
     "@eslint/eslintrc": "2.1.4",


### PR DESCRIPTION
pnpm移行に伴ってpublishに失敗するようになってしまった不具合への修正です :dog2: :dash:
（pre/post scriptsに依存している箇所があったが、`pnpm run` はデフォルトの設定で実行しない部分を見落としてました）

related: https://github.com/knowledge-work/eslint-config-kwork/pull/193
ref: https://github.com/knowledge-work/eslint-config-kwork/actions/runs/7204285093/job/19625482260