### PR TITLE
chore(ci): fix release pipeline (v2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile


### PR DESCRIPTION
以下、完全に見落としていて #193 のタイミングで消し去っていました :innocent:

> Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.
> https://github.com/actions/setup-node?tab=readme-ov-file#usage

ref: https://github.com/knowledge-work/eslint-config-kwork/actions/runs/7205776396/job/19629349837