### PR TITLE
chore(ci): fix release pipeline (v3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           git config user.name '[bot] github action (${{ github.workflow }})'
           git config user.email 'engineer-team@knowledgework.com'
-          pnpm version --${{ github.event_name == 'schedule' && 'patch' || github.event.inputs.versionClass }}
+          pnpm version ${{ github.event_name == 'schedule' && 'patch' || github.event.inputs.versionClass }}
           pnpm release
           echo "new_version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
#197 と同様、 #193 での移行での確認漏れです :pray:（flags -> args）

```shell
$ pnpm version --help
Bump a package version

Usage:
npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
```

ref: https://github.com/knowledge-work/eslint-config-kwork/actions/runs/7206404153/job/19631154883